### PR TITLE
Service add form logic

### DIFF
--- a/static/app/controllers.js
+++ b/static/app/controllers.js
@@ -87,11 +87,13 @@
             if (response.status == 400) {
                 $scope.message = {type: 'error', message: response.data.description}
             } else {
-                $scope.message = {type: 'success', message: "Service Created!"};
+                 $scope.activePlan = null;
+                 $scope.message = {type: 'success', message: "Service Created!"};
             }
         };
         // Show maker and populate with space info
         $scope.showServiceMaker = function(plan) {
+            $scope.message = null;
             $scope.activePlan = plan;
         };
         // Send request to create service instance

--- a/static/app/views/service.html
+++ b/static/app/views/service.html
@@ -3,6 +3,9 @@
     <p class="text-center">{{service.entity.description}}</p>
 </div>
 
+<div ng-show='message.type=="success"' class="alert alert-success" role="alert">{{message.message}}</div>
+
+
 <form>
     <div class="form-group">
         <div class="input-group">

--- a/static/app/views/servicemaker.html
+++ b/static/app/views/servicemaker.html
@@ -1,10 +1,7 @@
 <div class="well">
     <h4 class="text-center">Create Service Instance for <u>{{service.entity.label}}</u> service using the <u>{{activePlan.entity.name}}</u> plan </h4>
     </br>
-    <div ng-switch='message.type'>
-      <div ng-switch-when='error' class="alert alert-danger" role="alert">{{message.message}}</div>
-      <div ng-switch-when='success' class="alert alert-success" role="alert">{{message.message}}</div>
-    </div>
+      <div ng-show='message.type=="error"' class="alert alert-danger" role="alert">{{message.message}}</div> 
     <form>
         <div class="form-group">
             <label>Choose a name for the service</label>


### PR DESCRIPTION
Adds warning and success messages. If the service is created the form is hidden and a success messages appears. 
https://trello.com/c/LkBTOMxe/130-ui-add-a-service-instance

We could also add one of [these](http://angularjs4u.com/services/top-5-angularjs-flash-message-services-2014/).

### Service Maker
<img width="810" alt="screen shot 2015-08-11 at 4 59 39 pm" src="https://cloud.githubusercontent.com/assets/4596845/9210469/85140662-404a-11e5-8c8f-d752c61d0e35.png">
### Error
<img width="837" alt="screen shot 2015-08-11 at 4 59 56 pm" src="https://cloud.githubusercontent.com/assets/4596845/9210468/85101908-404a-11e5-8739-6c00354cc730.png">
### Success
<img width="823" alt="screen shot 2015-08-11 at 5 00 13 pm" src="https://cloud.githubusercontent.com/assets/4596845/9210467/850c8630-404a-11e5-9632-8bd39bf661a9.png">
### When service maker is clicked again
<img width="810" alt="screen shot 2015-08-11 at 4 59 39 pm" src="https://cloud.githubusercontent.com/assets/4596845/9210469/85140662-404a-11e5-8c8f-d752c61d0e35.png">


Thoughts, @dlapiduz @jcscottiii ?