### PR TITLE
Stopped adding routes from resetting app

### DIFF
--- a/static/app/cloudfoundry.js
+++ b/static/app/cloudfoundry.js
@@ -42,19 +42,21 @@
                 });
         };
 
-        // Delete Route
+        // Create a Route
         this.createRoute = function(newRoute, appGuid) {
             // Create the route
-            return $http.post('/v2/routes', newRoute)
+            return $http.post('/v2/routes?async=true&inline-relations-depth=1', newRoute)
                 .then(function(response) {
                     // Map the route to the app
-                    return $http.put(response.data.metadata.url + '/apps/' + appGuid)
+                    return $http.put('/v2/apps/' + appGuid + '/routes/' + response.data.metadata.guid)
                         .then(function(response) {
-                            return response.data;
+                            return response;
                         });
+                })
+                .catch(function (response) {
+                    return response;
                 });
         };
-
 
         // Get organizations
         this.getOrgs = function() {

--- a/static/app/views/app.html
+++ b/static/app/views/app.html
@@ -195,7 +195,7 @@
             </td>
             <td>
                 <button type="button" type="submit" class="btn btn-xs btn-info" ng-disabled="blockRoutes"
-                mwl-confirm title="Notice!" message="Please allow a few minutes for route to be finalized"
+                mwl-confirm title="Notice!" message="Please allow a few moments for the route to be created"
                 on-confirm="createRoute(newRoute)" confirm-button-type="info" cancel-button-type="default">
                     Create Route
                 </button>

--- a/static/tests/CFService_tests.js
+++ b/static/tests/CFService_tests.js
@@ -90,16 +90,16 @@ describe('CloudFoundry Service Tests', function() {
                 domain_guid: 'domainguid',
                 host: 'host'
             };
-            httpBackend.whenPOST('/v2/routes', newRoute).respond({
+            httpBackend.whenPOST('/v2/routes?async=true&inline-relations-depth=1', newRoute).respond({
                 metadata: {
-                    url: '/v2/routes/routeguid'
+                    guid: 'routeguid'
                 }
             })
-            httpBackend.whenPUT('/v2/routes/routeguid/apps/appguid').respond({
+            httpBackend.whenPUT('/v2/apps/appguid/routes/routeguid').respond({
                 status: 'put'
             });
             $cloudfoundry.createRoute(newRoute, 'appguid').then(function(response) {
-                expect(response).toEqual({
+                expect(response.data).toEqual({
                     status: 'put'
                 });
             });
@@ -111,11 +111,11 @@ describe('CloudFoundry Service Tests', function() {
                 domain_guid: 'domainguid',
                 host: 'host'
             };
-            httpBackend.whenPOST('/v2/routes', newRoute).respond(400, {
+            httpBackend.whenPOST('/v2/routes?async=true&inline-relations-depth=1', newRoute).respond(400, {
                 status: 'failed'
             });
             $cloudfoundry.createRoute(newRoute, 'appguid').then(function(response) {
-                expect(response).toEqual({
+                expect(response.data).toEqual({
                     status: 'failed'
                 });
             });
@@ -127,16 +127,16 @@ describe('CloudFoundry Service Tests', function() {
                 domain_guid: 'domainguid',
                 host: 'host'
             };
-            httpBackend.whenPOST('/v2/routes', newRoute).respond({
+            httpBackend.whenPOST('/v2/routes?async=true&inline-relations-depth=1', newRoute).respond({
                 metadata: {
-                    url: '/v2/routes/routeguid'
+                    guid: 'routeguid'
                 }
             })
-            httpBackend.whenPUT('/v2/routes/routeguid/apps/appguid').respond(400, {
+            httpBackend.whenPUT('/v2/apps/appguid/routes/routeguid').respond(400, {
                 status: 'put_failed'
             });
             $cloudfoundry.createRoute(newRoute, 'appguid').then(function(response) {
-                expect(response).toEqual({
+                expect(response.data).toEqual({
                     status: 'put_failed'
                 });
             });


### PR DESCRIPTION
[This endpoint](http://apidocs.cloudfoundry.org/215/routes/associate_app_with_the_route.html) resets the app while [this one](http://apidocs.cloudfoundry.org/215/apps/associate_route_with_the_app.html) does not. 